### PR TITLE
Email Confirmation

### DIFF
--- a/account/views.py
+++ b/account/views.py
@@ -276,14 +276,14 @@ class ConfirmEmailView(TemplateResponseMixin, View):
     
     def get(self, *args, **kwargs):
         self.object = confirmation = self.get_object()
-        if confirmation.email_address.user != self.request.user:
+        if self.request.user.is_authenticated() and confirmation.email_address.user != self.request.user:
             raise Http404()
         ctx = self.get_context_data()
         return self.render_to_response(ctx)
     
     def post(self, *args, **kwargs):
         self.object = confirmation = self.get_object()
-        if confirmation.email_address.user != self.request.user:
+        if self.request.user.is_authenticated() and confirmation.email_address.user != self.request.user:
             raise Http404()
         confirmation.confirm()
         user = confirmation.email_address.user


### PR DESCRIPTION
When requiring email confirmation, users cannot login until after they've confirmed their email, but ConfirmEmail checks that the current logged in user == the user associated with the confirmation. Fix this.
