### PR TITLE
Fix typo in LogoutView

### DIFF
--- a/account/views.py
+++ b/account/views.py
@@ -309,7 +309,7 @@ class LogoutView(TemplateResponseMixin, View):
     def get_redirect_url(self, fallback_url=None, **kwargs):
         if fallback_url is None:
             fallback_url = settings.ACCOUNT_LOGOUT_REDIRECT_URL
-        kwargs.setdefault("redirect_field_name", self.get_redirect_field_name())
+        self.kwargs.setdefault("redirect_field_name", self.get_redirect_field_name())
         return default_redirect(self.request, fallback_url, **kwargs)
 
 class ConfirmEmailView(TemplateResponseMixin, View):


### PR DESCRIPTION
An typo in LogoutView with kwargs instead of self.kwargs usage and 500 error on logout attempt.
