### PR TITLE
Set AccountDeletion.user to None

### DIFF
--- a/account/callbacks.py
+++ b/account/callbacks.py
@@ -6,3 +6,4 @@ def account_delete_mark(deletion):
 
 def account_delete_expunge(deletion):
     deletion.user.delete()
+    deletion.user = None


### PR DESCRIPTION
This is required to avoid a 'Key is not present in
auth_user table' exception. I suspect the on_delete
directive is not handling this because the deletion
object is an instance in memory versus getting
selected for deletion.
