### PR TITLE
get_context_data key misses return as "None" and possibly rendered in template

### DIFF
--- a/account/views.py
+++ b/account/views.py
@@ -76,7 +76,7 @@ class SignupView(FormView):
         redirect_field_name = self.get_redirect_field_name()
         ctx.update({
             "redirect_field_name": redirect_field_name,
-            "redirect_field_value": self.request.REQUEST.get(redirect_field_name),
+            "redirect_field_value": self.request.REQUEST.get(redirect_field_name, ""),
         })
         return ctx
     
@@ -238,7 +238,7 @@ class LoginView(FormView):
         redirect_field_name = self.get_redirect_field_name()
         ctx.update({
             "redirect_field_name": redirect_field_name,
-            "redirect_field_value": self.request.REQUEST.get(redirect_field_name),
+            "redirect_field_value": self.request.REQUEST.get(redirect_field_name, ""),
         })
         return ctx
     
@@ -299,7 +299,7 @@ class LogoutView(TemplateResponseMixin, View):
         redirect_field_name = self.get_redirect_field_name()
         ctx.update({
             "redirect_field_name": redirect_field_name,
-            "redirect_field_value": self.request.REQUEST.get(redirect_field_name),
+            "redirect_field_value": self.request.REQUEST.get(redirect_field_name, ""),
         })
         return ctx
     
@@ -435,7 +435,7 @@ class ChangePasswordView(FormView):
         redirect_field_name = self.get_redirect_field_name()
         ctx.update({
             "redirect_field_name": redirect_field_name,
-            "redirect_field_value": self.request.REQUEST.get(redirect_field_name),
+            "redirect_field_value": self.request.REQUEST.get(redirect_field_name, ""),
         })
         return ctx
     
@@ -538,7 +538,7 @@ class PasswordResetTokenView(FormView):
             "uidb36": self.kwargs["uidb36"],
             "token": self.kwargs["token"],
             "redirect_field_name": redirect_field_name,
-            "redirect_field_value": self.request.REQUEST.get(redirect_field_name),
+            "redirect_field_value": self.request.REQUEST.get(redirect_field_name, ""),
         })
         return ctx
     
@@ -642,7 +642,7 @@ class SettingsView(LoginRequiredMixin, FormView):
         redirect_field_name = self.get_redirect_field_name()
         ctx.update({
             "redirect_field_name": redirect_field_name,
-            "redirect_field_value": self.request.REQUEST.get(redirect_field_name),
+            "redirect_field_value": self.request.REQUEST.get(redirect_field_name, ""),
         })
         return ctx
     


### PR DESCRIPTION
Both the empty string and `None` evaluate to not true, but `None` will be displayed as "None" in a template. Setting an empty string default obviates the need for template conditionals to display or not display the next value.

This:

``` html
<input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}">
```

Will, with default values, render as this:

``` html
<input type="hidden" name="next" value="None">
```

Which results in a `NoReverseMatch` error because the given URL path is "None". The solution is a template conditional:

``` html
{% if redirect_field_value %}
<input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}">
{% endif %}
```

But this shouldn't be necessary. Since the empty string also evaluate to False this shouldn't be expected to break backwards compatibility for existing code.
