### PR TITLE
Allow use with auth backends that don't require username/password

### DIFF
--- a/account/auth_backends.py
+++ b/account/auth_backends.py
@@ -18,7 +18,7 @@ class UsernameAuthenticationBackend(ModelBackend):
                 if user.check_password(credentials["password"]):
                     return user
             except KeyError:
- 
+               return None 
 
 class EmailAuthenticationBackend(ModelBackend):
     


### PR DESCRIPTION
Previously, this would throw a `KeyError` which prevented this to be used in conjunction with an auth backend I'm writing which accepts only a `token` key.
