### PR TITLE
Use get_current_site(), instead of Site.get_current()

### DIFF
--- a/account/views.py
+++ b/account/views.py
@@ -110,7 +110,7 @@ class SignupView(FormView):
         email_address = EmailAddress.objects.add_email(self.created_user, self.created_user.email, **email_kwargs)
         self.after_signup(form)
         if settings.ACCOUNT_EMAIL_CONFIRMATION_EMAIL and not email_kwargs["verified"]:
-            email_address.send_confirmation()
+            email_address.send_confirmation(get_current_site(self.request))
         if settings.ACCOUNT_EMAIL_CONFIRMATION_REQUIRED and not email_kwargs["verified"]:
             response_kwargs = {
                 "request": self.request,


### PR DESCRIPTION
django-user-accounts requires the sites framework to be in use, which makes things awkward for those who would prefer to use `RequestSite` (e.g. we're using django-hosts).

This adds a new `site` parameter to email-sending methods, which is passed through from the view. The view uses `get_current_site(request)`, instead of `Site.get_current()`, as the more generic (and `RequestSite`-aware) way to get a `Site`-like object.
