### PR TITLE
Add /logout_now/, for one-click logouts without confirmation

### DIFF
--- a/account/urls.py
+++ b/account/urls.py
@@ -1,6 +1,6 @@
 from django.conf.urls import patterns, url
 
-from account.views import SignupView, LoginView, LogoutView, DeleteView
+from account.views import SignupView, LoginView, LogoutView, LogoutOneClickView, DeleteView
 from account.views import ConfirmEmailView
 from account.views import ChangePasswordView, PasswordResetView, PasswordResetTokenView
 from account.views import SettingsView
@@ -10,6 +10,7 @@ urlpatterns = patterns("",
     url(r"^signup/$", SignupView.as_view(), name="account_signup"),
     url(r"^login/$", LoginView.as_view(), name="account_login"),
     url(r"^logout/$", LogoutView.as_view(), name="account_logout"),
+    url(r"^logout_now/$", LogoutOneClickView.as_view(), name="account_logout_oneclick"),
     url(r"^confirm_email/(?P<key>\w+)/$", ConfirmEmailView.as_view(), name="account_confirm_email"),
     url(r"^password/$", ChangePasswordView.as_view(), name="account_password"),
     url(r"^password/reset/$", PasswordResetView.as_view(), name="account_password_reset"),

--- a/account/views.py
+++ b/account/views.py
@@ -326,6 +326,15 @@ class LogoutView(TemplateResponseMixin, View):
         kwargs.setdefault("redirect_field_name", self.get_redirect_field_name())
         return default_redirect(self.request, fallback_url, **kwargs)
 
+
+class LogoutOneClickView(LogoutView):
+
+    def get(self, *args, **kwargs):
+        if self.request.user.is_authenticated():
+            auth.logout(self.request)
+        return redirect(self.get_redirect_url())
+
+
 class ConfirmEmailView(TemplateResponseMixin, View):
     
     messages = {


### PR DESCRIPTION
Some sites don't want to make their users confirm a logout -- if they logged out by mistake, they can just log back in again.  This patch adds /logout_now/ to perform an instant logout via HTTP GET.
