### PR TITLE
Only allow get and post requests

### DIFF
--- a/account/views.py
+++ b/account/views.py
@@ -331,6 +331,7 @@ class LogoutView(TemplateResponseMixin, View):
 
 class ConfirmEmailView(TemplateResponseMixin, View):
 
+    http_method_names = ["get", "post"]
     messages = {
         "email_confirmed": {
             "level": messages.SUCCESS,


### PR DESCRIPTION
Sometimes bots will hit this view with HEAD requests which
generates exceptions. This should enable Django to return
a proper HTTP response code saying that method is not allowed.
