### PR TITLE
fwd and bkwd compatible form field ordering

### DIFF
--- a/account/forms.py
+++ b/account/forms.py
@@ -106,7 +106,7 @@ class LoginUsernameForm(LoginForm):
     def __init__(self, *args, **kwargs):
         super(LoginUsernameForm, self).__init__(*args, **kwargs)
         field_order = ["username", "password", "remember"]
-        if not OrderedDict or "keyOrder" in self.fields:
+        if not OrderedDict or hasattr(self.fields, "keyOrder"):
             self.fields.keyOrder = field_order
         else:
             self.fields = OrderedDict((k, self.fields[k]) for k in field_order)
@@ -121,7 +121,7 @@ class LoginEmailForm(LoginForm):
     def __init__(self, *args, **kwargs):
         super(LoginEmailForm, self).__init__(*args, **kwargs)
         field_order = ["email", "password", "remember"]
-        if not OrderedDict or "keyOrder" in self.fields:
+        if not OrderedDict or hasattr(self.fields, "keyOrder"):
             self.fields.keyOrder = field_order
         else:
             self.fields = OrderedDict((k, self.fields[k]) for k in field_order)


### PR DESCRIPTION
- undocumented keyOrder has gone missing on django master. 
- support Python < 2.7 which don't have collections.OrderedDict
- lint dictionary

see: https://github.com/pennersr/django-allauth/issues/356 for a similar discussion
