### PR TITLE
Fix timezone middleware

### DIFF
--- a/account/middleware.py
+++ b/account/middleware.py
@@ -43,7 +43,10 @@ class TimezoneMiddleware(object):
     """
 
     def process_request(self, request):
-        account = getattr(request.user, "account", None)
+        try:
+            account = getattr(request.user, "account", None)
+        except Account.DoesNotExist:
+            account = None
         if account:
             tz = settings.TIME_ZONE if not account.timezone else account.timezone
             timezone.activate(tz)


### PR DESCRIPTION
Small fix to avoid raising an exception when migrating an existing app and there is no user account in the database yet.

Cheers
