### PR TITLE
Write django-user-accounts instead of d-u-a

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -27,7 +27,7 @@ Why can email addresses get out of sync?
 ========================================
 
 django-user-accounts stores email addresses in two locations. The default
-``User`` model contains an ``email`` field and d-u-a provides an
+``User`` model contains an ``email`` field and django-user-accounts provides an
 ``EmailAddress`` model. This latter is provided to support multiple email
 addresses per user.
 


### PR DESCRIPTION
While reading the FAQ I stumbled over `d-u-a`. I hadn't seen it anywhere in the documentation. I searched the term before realizing it was `django-user-accounts`. (Duh.) I propose you spell it out and save the next person some confusion. Alternatively, consider referring to the project as `d-u-a` throughout for consistency.
