### PR TITLE
Email length set to be equal to the username field in the Sign Up Form

### DIFF
--- a/account/forms.py
+++ b/account/forms.py
@@ -39,6 +39,7 @@ class SignupForm(forms.Form):
     )
     email = forms.EmailField(
         label=_("Email"),
+        max_length=30,
         widget=forms.TextInput(), required=True)
 
     code = forms.CharField(


### PR DESCRIPTION
We use Email address as username, and a user tried to log in using a very long email Address, breaking the database constrain (we use the email as username and emai field.)
