### PR TITLE
Fix the search on EmailAddress admin.

### DIFF
--- a/account/admin.py
+++ b/account/admin.py
@@ -14,7 +14,7 @@ class SignupCodeAdmin(admin.ModelAdmin):
 
 class EmailAddressAdmin(admin.ModelAdmin):
     list_display = ["user", "email", "verified", "primary"]
-    search_fields = ["user", "email"]
+    search_fields = ["email", "user__username"]
     list_filter = ["user"]
 
 


### PR DESCRIPTION
We cannot query a foreign key directly, but we need to
specify one field. Now we query the username
