### PR TITLE
import get_current_site from django.contrib.sites.shortcuts.

### DIFF
--- a/account/models.py
+++ b/account/models.py
@@ -16,7 +16,6 @@ from django.utils import timezone, translation, six
 from django.utils.translation import ugettext_lazy as _
 
 from django.contrib.auth.models import AnonymousUser
-from django.contrib.sites.models import Site
 
 import pytz
 
@@ -208,7 +207,7 @@ class SignupCode(models.Model):
 
     def send(self, **kwargs):
         protocol = getattr(settings, "DEFAULT_HTTP_PROTOCOL", "http")
-        current_site = kwargs["site"] if "site" in kwargs else Site.objects.get_current()
+        current_site = kwargs.get("site")
         if "signup_url" not in kwargs:
             signup_url = "{0}://{1}{2}?{3}".format(
                 protocol,
@@ -277,7 +276,7 @@ class EmailAddress(models.Model):
         confirmation.send(**kwargs)
         return confirmation
 
-    def change(self, new_email, confirm=True):
+    def change(self, new_email, confirm=True, **kwargs):
         """
         Given a new email address, change self and re-confirm.
         """
@@ -288,7 +287,7 @@ class EmailAddress(models.Model):
             self.verified = False
             self.save()
             if confirm:
-                self.send_confirmation()
+                self.send_confirmation(**kwargs)
 
 
 class EmailConfirmation(models.Model):
@@ -327,8 +326,8 @@ class EmailConfirmation(models.Model):
             return email_address
 
     def send(self, **kwargs):
-        current_site = kwargs["site"] if "site" in kwargs else Site.objects.get_current()
         protocol = getattr(settings, "DEFAULT_HTTP_PROTOCOL", "http")
+        current_site = kwargs.get("site")
         activate_url = "{0}://{1}{2}".format(
             protocol,
             current_site.domain,

--- a/account/views.py
+++ b/account/views.py
@@ -9,7 +9,12 @@ from django.views.generic.base import TemplateResponseMixin, View
 from django.views.generic.edit import FormView
 
 from django.contrib import auth, messages
-from django.contrib.sites.shortcuts import get_current_site
+
+try:
+    from django.contrib.sites.shortcuts import get_current_site
+except ImportError:
+    from django.contrib.sites.models import get_current_site
+
 from django.contrib.auth.tokens import default_token_generator
 
 from account import signals

--- a/account/views.py
+++ b/account/views.py
@@ -9,7 +9,7 @@ from django.views.generic.base import TemplateResponseMixin, View
 from django.views.generic.edit import FormView
 
 from django.contrib import auth, messages
-from django.contrib.sites.models import get_current_site
+from django.contrib.sites.shortcuts import get_current_site
 from django.contrib.auth.tokens import default_token_generator
 
 from account import signals

--- a/account/views.py
+++ b/account/views.py
@@ -706,7 +706,7 @@ class SettingsView(LoginRequiredMixin, FormView):
             user.save()
         else:
             if email != self.primary_email_address.email:
-                self.primary_email_address.change(email, confirm=confirm)
+                self.primary_email_address.change(email, confirm=confirm, site=get_current_site(self.request))
 
     def get_context_data(self, **kwargs):
         ctx = kwargs


### PR DESCRIPTION
django.contrib.sites.shortcuts.get_current_site is deprecated in Django 1.7.

    account/views.py:207: RemovedInDjango19Warning: Please import get_current_site from
    django.contrib.sites.shortcuts.

