### PR TITLE
Added `user` and `inviter` to admin `raw_id_fields`

### DIFF
--- a/account/admin.py
+++ b/account/admin.py
@@ -10,15 +10,27 @@ class SignupCodeAdmin(admin.ModelAdmin):
     list_display = ["code", "max_uses", "use_count", "expiry", "created"]
     search_fields = ["code", "email"]
     list_filter = ["created"]
+    raw_id_fields = ["inviter"]
 
 
-class EmailAddressAdmin(admin.ModelAdmin):
+class AccountAdmin(admin.ModelAdmin):
+
+    raw_id_fields = ["user"]
+
+
+class AccountDeletionAdmin(AccountAdmin):
+
+    list_display = ["email", "date_requested", "date_expunged"]
+
+
+class EmailAddressAdmin(AccountAdmin):
+
     list_display = ["user", "email", "verified", "primary"]
     search_fields = ["email", "user__username"]
     list_filter = ["user"]
 
 
-admin.site.register(Account)
+admin.site.register(Account, AccountAdmin)
 admin.site.register(SignupCode, SignupCodeAdmin)
-admin.site.register(AccountDeletion, list_display=["email", "date_requested", "date_expunged"])
+admin.site.register(AccountDeletion, AccountDeletionAdmin)
 admin.site.register(EmailAddress, EmailAddressAdmin)


### PR DESCRIPTION
Loading all users into a drop-down list is impractical when you have thousands of users. It makes sense to add user refs to raw_id_fields to reduce overhead and use the full power of the admin to find/select users.