### PR TITLE
Fix TransactionManagementError

### DIFF
--- a/account/models.py
+++ b/account/models.py
@@ -281,7 +281,7 @@ class EmailAddress(models.Model):
         """
         Given a new email address, change self and re-confirm.
         """
-        with transaction.commit_on_success():
+        with transaction.atomic():
             self.user.email = new_email
             self.user.save()
             self.email = new_email


### PR DESCRIPTION
Fix TransactionManagementError when update user email address via SettingsView in Django 1.7 which ATOMIC_REQUEST is enabled.

More info: http://stackoverflow.com/a/26219688