### PR TITLE
Docs: use full code-blocks for python highlighting

### DIFF
--- a/docs/templates.rst
+++ b/docs/templates.rst
@@ -58,10 +58,14 @@ Emails (actual emails themselves)::
 Template Tags
 =============
 
-To use the built in template tags you must first load them within the templates::
+To use the built in template tags you must first load them within the templates:
+
+.. code-block:: python
 
     {% load account_tags %}
 
-To display the current logged-in user::
+To display the current logged-in user:
+
+.. code-block:: python
 
     {% user_display request.user %}

--- a/docs/templates.rst
+++ b/docs/templates.rst
@@ -60,12 +60,12 @@ Template Tags
 
 To use the built in template tags you must first load them within the templates:
 
-.. code-block:: python
+.. code-block:: jinja
 
     {% load account_tags %}
 
 To display the current logged-in user:
 
-.. code-block:: python
+.. code-block:: jinja
 
     {% user_display request.user %}


### PR DESCRIPTION
In reStructuredText ``::`` shows as an ordinary code block and doesn't run through python pygments.