### PR TITLE
Bugfix: Constrained backend authenticate() methods to only accept username and password

### DIFF
--- a/account/auth_backends.py
+++ b/account/auth_backends.py
@@ -10,10 +10,10 @@ from account.models import EmailAddress
 
 class UsernameAuthenticationBackend(ModelBackend):
 
-    def authenticate(self, **credentials):
+    def authenticate(self, username, password, **credentials):
         User = get_user_model()
         lookup_kwargs = get_user_lookup_kwargs({
-            "{username}__iexact": credentials["username"]
+            "{username}__iexact": username,
         })
         try:
             user = User.objects.get(**lookup_kwargs)
@@ -21,7 +21,7 @@ class UsernameAuthenticationBackend(ModelBackend):
             return None
         else:
             try:
-                if user.check_password(credentials["password"]):
+                if user.check_password(password):
                     return user
             except KeyError:
                 return None
@@ -29,16 +29,16 @@ class UsernameAuthenticationBackend(ModelBackend):
 
 class EmailAuthenticationBackend(ModelBackend):
 
-    def authenticate(self, **credentials):
+    def authenticate(self, username, password, **credentials):
         qs = EmailAddress.objects.filter(Q(primary=True) | Q(verified=True))
         try:
-            email_address = qs.get(email__iexact=credentials["username"])
+            email_address = qs.get(email__iexact=username)
         except (EmailAddress.DoesNotExist, KeyError):
             return None
         else:
             user = email_address.user
             try:
-                if user.check_password(credentials["password"]):
+                if user.check_password(password):
                     return user
             except KeyError:
                 return None


### PR DESCRIPTION
The reason for this change is that we want to raise a TypeError if the wrong
types of credentials are input to authenticate():

https://github.com/django/django/blob/b06dfad88fb12a927c86a1eb23064201c9560fb1/django/contrib/auth/__init__.py#L64

Right now, one of these authenticate() methods could conceivably raise a
KeyError instead if no "username" kwarg is supplied (I had this happen to me in
my own code while installing a new authentication backend).