### PR TITLE
Use form prefix and identifier_field when dispatching signals

### DIFF
--- a/account/utils.py
+++ b/account/utils.py
@@ -88,3 +88,11 @@ def handle_redirect_to_login(request, **kwargs):
         querystring[redirect_field_name] = next_url
         url_bits[4] = querystring.urlencode(safe="/")
     return HttpResponseRedirect(urlunparse(url_bits))
+
+
+def get_form_data(form, field_name, default=None):
+    if form.prefix:
+        key = "-".join([form.prefix, field_name])
+    else:
+        key = field_name
+    return form.data.get(key, default)

--- a/account/views.py
+++ b/account/views.py
@@ -21,7 +21,7 @@ from account.forms import SettingsForm
 from account.hooks import hookset
 from account.mixins import LoginRequiredMixin
 from account.models import SignupCode, EmailAddress, EmailConfirmation, Account, AccountDeletion
-from account.utils import default_redirect
+from account.utils import default_redirect, get_form_data
 
 
 class SignupView(FormView):
@@ -114,8 +114,8 @@ class SignupView(FormView):
     def form_invalid(self, form):
         signals.user_sign_up_attempt.send(
             sender=SignupForm,
-            username=form.data.get("username"),
-            email=form.data.get("email"),
+            username=get_form_data(form, "username"),
+            email=get_form_data(form, "email"),
             result=form.is_valid()
         )
         return super(SignupView, self).form_invalid(form)
@@ -307,7 +307,7 @@ class LoginView(FormView):
     def form_invalid(self, form):
         signals.user_login_attempt.send(
             sender=LoginView,
-            username=form.data.get(form.identifier_field),
+            username=get_form_data(form, form.identifier_field),
             result=form.is_valid()
         )
         return super(LoginView, self).form_invalid(form)

--- a/account/views.py
+++ b/account/views.py
@@ -114,7 +114,7 @@ class SignupView(FormView):
     def form_invalid(self, form):
         signals.user_sign_up_attempt.send(
             sender=SignupForm,
-            username=get_form_data(form, "username"),
+            username=get_form_data(form, self.identifier_field),
             email=get_form_data(form, "email"),
             result=form.is_valid()
         )


### PR DESCRIPTION
Signals will now include form data if the form has a prefix, and will respect customizations to SignUp/Login views when a custom identifier_field is set.