### PR TITLE
remove list_filter from EmailAddressAdmin

### DIFF
--- a/account/admin.py
+++ b/account/admin.py
@@ -27,7 +27,6 @@ class EmailAddressAdmin(AccountAdmin):
 
     list_display = ["user", "email", "verified", "primary"]
     search_fields = ["email", "user__username"]
-    list_filter = ["user"]
 
 
 admin.site.register(Account, AccountAdmin)


### PR DESCRIPTION
The list filter in EmailAddressAdmin is not necessary because the username is searchable; and because the list filter will look really bad if there are thousands of users.