### PR TITLE
Fix deprecation warning when importing get_current_site

### DIFF
--- a/account/views.py
+++ b/account/views.py
@@ -10,7 +10,7 @@ from django.views.generic.edit import FormView
 
 from django.contrib import auth, messages
 from django.contrib.auth import get_user_model
-from django.contrib.sites.models import get_current_site
+from django.contrib.sites.shortcuts import get_current_site
 from django.contrib.auth.tokens import default_token_generator
 
 from account import signals


### PR DESCRIPTION
Deprecated in 1.7 and will be removed in 1.9:
https://docs.djangoproject.com/en/dev/releases/1.7/#reorganization-of-django-contrib-sites