### PR TITLE
Include assets in source tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include README.rst
 recursive-include account/locale *
+recursive-include docs Makefile conf.py *.rst

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include README.rst
+include runtests.py
 recursive-include account/locale *
 recursive-include docs Makefile conf.py *.rst


### PR DESCRIPTION
I would like to package django-user-accounts for Debian. Having the documentation and the tests in the source tarball published on pypi would allow me to use both during package build, providing test-coverage with the Python versions available in Debian and to ship a separate documentation package.