### PR TITLE
Correct link to source for available languages

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -147,4 +147,4 @@ Default: ``list(zip(pytz.all_timezones, pytz.all_timezones))``
 ``ACCOUNT_LANGUAGES``
 =====================
 
-See full list in: https://github.com/pinax/django-user-accounts/blob/master/account/language_list.py
+See full list in: https://github.com/pinax/django-user-accounts/blob/master/account/languages.py


### PR DESCRIPTION
This change only updates a link inside documentation point to list of available languages.