### PR TITLE
Avoid a KeyError due to identifier_field.

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -174,6 +174,7 @@ If you want to get rid of username you'll need to do some extra work:
        class SignupView(account.views.SignupView):
 
            form_class = myproject.forms.SignupForm
+           identifier_field = 'email'
 
            def generate_username(self, form):
                # do something to generate a unique username (required by the


### PR DESCRIPTION
Resolved a KeyError issue by making the change above. It might be worthwhile to mention something related to this in the documentation. Appears to be also related to #227.

Reference: https://github.com/pinax/django-user-accounts/blob/master/account/views.py#L290