### PR TITLE
forms.SignupForm: move "email" before "password"

### DIFF
--- a/account/forms.py
+++ b/account/forms.py
@@ -47,6 +47,10 @@ class SignupForm(forms.Form):
         widget=forms.TextInput(),
         required=True
     )
+    email = forms.EmailField(
+        label=_("Email"),
+        widget=forms.TextInput(), required=True
+    )
     password = PasswordField(
         label=_("Password"),
         strip=settings.ACCOUNT_PASSWORD_STRIP,
@@ -55,10 +59,6 @@ class SignupForm(forms.Form):
         label=_("Password (again)"),
         strip=settings.ACCOUNT_PASSWORD_STRIP,
     )
-    email = forms.EmailField(
-        label=_("Email"),
-        widget=forms.TextInput(), required=True)
-
     code = forms.CharField(
         max_length=64,
         required=False,


### PR DESCRIPTION
Move the field "email" before "password". This way it will also appear before "password" on the signup view. Otherwise, by default, if using signup with email only, the "email" field appears after "password" and it looks awkward.