### PR TITLE
Add note about login_required

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -21,6 +21,11 @@ this app will:
 The rest of this document will cover how you can tweak the default behavior
 of django-user-accounts.
 
+Limiting access to views
+========================
+
+To limit view access to logged in users, normally you would use the Django decorator ``django.contrib.auth.decorators.login_required``.  Instead you should use ``account.decorators.login_required``.
+
 
 Customizing the sign up process
 ===============================


### PR DESCRIPTION
If you use Django's login_required decorator, some stuff doesn't work
correctly.  Clearly indicate that developers should use our
login_required decorator instead.