### PR TITLE
If newly-created user cannot be authenticated, blame configuration

### DIFF
--- a/account/views.py
+++ b/account/views.py
@@ -5,6 +5,7 @@ from django.contrib.auth import get_user_model
 from django.contrib.auth.hashers import make_password
 from django.contrib.auth.tokens import default_token_generator
 from django.contrib.sites.shortcuts import get_current_site
+from django.core.exceptions import ImproperlyConfigured
 from django.http import Http404, HttpResponseForbidden
 from django.shortcuts import get_object_or_404, redirect
 from django.utils.decorators import method_decorator
@@ -301,6 +302,8 @@ class SignupView(PasswordMixin, FormView):
 
     def login_user(self):
         user = auth.authenticate(**self.user_credentials())
+        if not user:
+            raise ImproperlyConfigured("Configured auth backends failed to authenticate on signup")
         auth.login(self.request, user)
         self.request.session.set_expiry(0)
 


### PR DESCRIPTION
In case a newly-created user cannot be authenticated, this means there's
a mismatch between the fields used for creation and the authentication
backends.

This fixes a yet-unreported bug