### PR TITLE
add request arg to authenticate to work with Django 2.1

### DIFF
--- a/account/auth_backends.py
+++ b/account/auth_backends.py
@@ -10,7 +10,7 @@ from account.utils import get_user_lookup_kwargs
 
 class UsernameAuthenticationBackend(ModelBackend):
 
-    def authenticate(self, **credentials):
+    def authenticate(self, *args, **credentials):
         User = get_user_model()
         try:
             lookup_kwargs = get_user_lookup_kwargs({
@@ -29,7 +29,7 @@ class UsernameAuthenticationBackend(ModelBackend):
 
 class EmailAuthenticationBackend(ModelBackend):
 
-    def authenticate(self, **credentials):
+    def authenticate(self, *args, **credentials):
         qs = EmailAddress.objects.filter(Q(primary=True) | Q(verified=True))
         try:
             email_address = qs.get(email__iexact=credentials["username"])

--- a/account/tests/test_auth.py
+++ b/account/tests/test_auth.py
@@ -29,6 +29,18 @@ class UsernameAuthenticationBackendTestCase(TestCase):
         self.assertTrue(authenticate() is None)
         self.assertTrue(authenticate(username="user1") is None)
 
+    def test_successful_auth_django_2_1(self):
+        created_user = self.create_user("user1", "user1@example.com", "password")
+        request = None
+        authed_user = authenticate(request, username="user1", password="password")
+        self.assertTrue(authed_user is not None)
+        self.assertEqual(created_user.pk, authed_user.pk)
+
+    def test_unsuccessful_auth_django_2_1(self):
+        request = None
+        authed_user = authenticate(request, username="user-does-not-exist", password="password")
+        self.assertTrue(authed_user is None)
+
 
 @override_settings(
     AUTHENTICATION_BACKENDS=[
@@ -55,3 +67,15 @@ class EmailAuthenticationBackendTestCase(TestCase):
         self.create_user("user1", "user1@example.com", "password")
         self.assertTrue(authenticate() is None)
         self.assertTrue(authenticate(username="user1@example.com") is None)
+
+    def test_successful_auth_django_2_1(self):
+        created_user = self.create_user("user1", "user1@example.com", "password")
+        request = None
+        authed_user = authenticate(request, username="user1@example.com", password="password")
+        self.assertTrue(authed_user is not None)
+        self.assertEqual(created_user.pk, authed_user.pk)
+
+    def test_unsuccessful_auth_django_2_1(self):
+        request = None
+        authed_user = authenticate(request, username="user-does-not-exist", password="password")
+        self.assertTrue(authed_user is None)


### PR DESCRIPTION
Django 2.1 mandates that the first parameter passed to
backend.authenticate() must be request.  Without this, login simply
fails as if you had entered a wrong username/password.