### PR TITLE
Added signup form with email (but no username)

### DIFF
--- a/account/forms.py
+++ b/account/forms.py
@@ -90,6 +90,18 @@ class SignupForm(forms.Form):
         return self.cleaned_data
 
 
+class SignupEmailForm(SignupForm):
+
+    def __init__(self, *args, **kwargs):
+        super(SignupEmailForm, self).__init__(*args, **kwargs)
+        self.fields.pop("username")
+
+    def clean(self):
+        cleaned_data = super().clean()
+        cleaned_data["username"] = cleaned_data.get("email")
+        return cleaned_data
+
+
 class LoginForm(forms.Form):
 
     password = PasswordField(


### PR DESCRIPTION
Hey guys, I added a new SignupEmailForm based on SignupForm you have, I am not sure if adding a new setting is fine for you. while testing this app, I found an error, and is because when you have `EmailAuthenticationBackend` in `AUTHENTICATION_BACKENDS`, the SignupForm is still asking for a username, but is not saving username field, so when you try to [login](https://github.com/robertpro/django-user-accounts/blob/6973bcb33aeab046064a41bf20ec469fce4a1d50/account/views.py#L308) the user it can't login since `self.user_credentials` has `username` and `password`, but like I said `username` is empty.

So at this point user is AnonymousUser, so it fails in this [line](https://github.com/django/django/blob/master/django/contrib/auth/__init__.py#L125) which makes sense.

This PR is a proposal for that bug.

If this is OK for you, I will add tests regarding my change.