### PR TITLE
django-3-decorators

### DIFF
--- a/account/decorators.py
+++ b/account/decorators.py
@@ -1,7 +1,6 @@
 import functools
 
 from django.contrib.auth import REDIRECT_FIELD_NAME
-from django.utils.decorators import available_attrs
 
 from account.utils import handle_redirect_to_login
 
@@ -12,7 +11,7 @@ def login_required(func=None, redirect_field_name=REDIRECT_FIELD_NAME, login_url
     to the log in page if necessary.
     """
     def decorator(view_func):
-        @functools.wraps(view_func, assigned=available_attrs(view_func))
+        @functools.wraps(view_func)
         def _wrapped_view(request, *args, **kwargs):
             if request.user.is_authenticated:
                 return view_func(request, *args, **kwargs)

--- a/account/tests/test_decorators.py
+++ b/account/tests/test_decorators.py
@@ -1,0 +1,26 @@
+from unittest import mock
+
+from django.http import HttpResponse
+from django.test import TestCase
+
+from account.decorators import login_required
+
+
+@login_required
+def mock_view(request, *args, **kwargs):
+    return HttpResponse('OK', status=200)
+
+
+class LoginRequiredDecoratorTestCase(TestCase):
+
+    def test_authenticated_user_is_allowed(self):
+        request = mock.MagicMock()
+        request.user.is_authenticated = True
+        response = mock_view(request)
+        self.assertEqual(response.status_code, 200)
+
+    def test_unauthenticated_user_gets_redirected(self):
+        request = mock.MagicMock()
+        request.user.is_authenticated = False
+        response = mock_view(request)
+        self.assertEqual(response.status_code, 302)


### PR DESCRIPTION
Django 3 compatible decorators

[Django 3 removed `django.utils.decorators.available_attrs`](https://docs.djangoproject.com/en/3.0/releases/3.0/#removed-private-python-2-compatibility-apis).

It returns `functools.WRAPPER_ASSIGNMENTS`, but since [that's the default in `functools.wraps()`](https://docs.python.org/3/library/functools.html#functools.wraps) anyway, it became redundant and I removed it.

Added tests for the `login_required` decorator.