### PR TITLE
avoid passing a lazy string to urlparse

### DIFF
--- a/account/utils.py
+++ b/account/utils.py
@@ -6,6 +6,7 @@ from django.contrib.auth import get_user_model
 from django.core.exceptions import SuspiciousOperation
 from django.http import HttpResponseRedirect, QueryDict
 from django.urls import NoReverseMatch, reverse
+from django.utils.encoding import force_str
 
 import pytz
 from account.conf import settings
@@ -90,7 +91,7 @@ def handle_redirect_to_login(request, **kwargs):
             raise
         if "/" not in login_url and "." not in login_url:
             raise
-    url_bits = list(urlparse(login_url))
+    url_bits = list(urlparse(force_str(login_url)))
     if redirect_field_name:
         querystring = QueryDict(url_bits[4], mutable=True)
         querystring[redirect_field_name] = next_url


### PR DESCRIPTION
urlparse does not support reverse_lazy as url arg.
Much like Django bug [#18776](https://code.djangoproject.com/ticket/18776),
urlparse will fail with `AttributeError: '__proxy__' object has no
attribute 'decode'` if the url arg is from reverse_lazy.

