### PR TITLE
Drop deprecated `force_text()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 BI indicates a backward incompatible change. Take caution when upgrading to a
 version with these. Your code will need to be updated to continue working.
 
+## 3.0.3
+
+* Drop deprecated `force_text()`
+
+## 3.0.2
+
+* Drop Django 2.0 and Python 2,7, 3.4, and 3.5 support
+* Add Django 2.1, 2.2 and 3.0, and Python 3.7 and 3.8 support
+* Update packaging configs
+
 ## 2.0.3
 
  * fixed breaking change in 2.0.2 where context did not have uidb36 and token

--- a/account/forms.py
+++ b/account/forms.py
@@ -4,7 +4,7 @@ from collections import OrderedDict
 from django import forms
 from django.contrib import auth
 from django.contrib.auth import get_user_model
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.utils.translation import gettext_lazy as _
 
 from account.conf import settings
@@ -25,7 +25,7 @@ class PasswordField(forms.CharField):
     def to_python(self, value):
         if value in self.empty_values:
             return ""
-        value = force_text(value)
+        value = force_str(value)
         if self.strip:
             value = value.strip()
         return value

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="django-user-accounts",
-    version="3.0.2",
+    version="3.0.3",
     author="Brian Rosner",
     author_email="brosner@gmail.com",
     description="a Django user account app",


### PR DESCRIPTION
This PR improves Django 3 support in django-user-accounts.

~It will drop private Python 2 compatibility APIs as well as features deprecated in Django 3.0~

~It was inspired by (and will fix) https://github.com/pinax/django-user-accounts/issues/325, and was guided by the [Django 3.0 release notes](https://docs.djangoproject.com/en/dev/releases/3.0/).~

It will drop the deprecated utility function `django.utils.encoding.force_text()`, and replace it with `django.utils.encoding.force_str()`