### PR TITLE
PasswordReset send_email in views.py

### DIFF
--- a/account/views.py
+++ b/account/views.py
@@ -648,7 +648,7 @@ class PasswordResetView(FormView):
                 "current_site": current_site,
                 "password_reset_url": password_reset_url,
             }
-            hookset.send_password_reset_email([user.email], ctx)
+            hookset.send_password_reset_email([email], ctx)
 
     def make_token(self, user):
         return self.token_generator.make_token(user)


### PR DESCRIPTION
emails are sent to django.contrib.auth User model adress instead of account EmailAddress model adress

Closes # .

Changes proposed in this PR:

-
-

**Tips for an ideal PR**
* You have read our Code of Conduct: https://github.com/pinax/.github/blob/master/CODE_OF_CONDUCT.md
* You have read our Contributing info: https://github.com/pinax/.github/blob/master/CONTRIBUTING.md
* The PR is atomic
* Unit tests have been updated/added, if needed
* App version number has been updated in `setup.py` (Pinax uses [SemVer](https://semver.org/))
* `Change Log` has been updated

