### PR TITLE
Fix that CI isn't running on pull requests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,9 @@
 name: Lints and Tests
-on: [push]
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
 jobs:
   lint:
     name: Linting


### PR DESCRIPTION
The CI isn't running on pull requests, so there is no way of knowing whether a PR passes all the tests. So we should fix this. 

