### PR TITLE
Resolved the bug TypeError: can't compare offset-naive and offset-aware datetimes While cheching account is expred 

### DIFF
--- a/account/utils.py
+++ b/account/utils.py
@@ -131,7 +131,7 @@ def check_password_expired(user):
     except PasswordHistory.DoesNotExist:
         return False
 
-    now = datetime.datetime.now(tz=pytz.UTC)
+    now = datetime.datetime.now()
     expiration = latest.timestamp + datetime.timedelta(seconds=expiry)
 
     if expiration < now:


### PR DESCRIPTION
Closes # 354

Changes proposed in this PR:
when we have timezone set and we use for password expire this give error, as in utils.py at time of checking to expire , used UTC DateTime. 
Remove URL params from  DateTime.now


