### PR TITLE
ugettext_lazy -> gettext_lazy for Django 4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 BI indicates a backward incompatible change. Take caution when upgrading to a
 version with these. Your code will need to be updated to continue working.
 
+## 3.2.0
+
+* #363 - Django 4.0 compat: `ugettext_lazy` -> `gettext_lazy`
+
 ## 3.1.0
 
 * #205 - Bug fix on checking email against email not signup code

--- a/account/hooks.py
+++ b/account/hooks.py
@@ -4,7 +4,7 @@ import random
 from django import forms
 from django.core.mail import send_mail
 from django.template.loader import render_to_string
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from account.conf import settings
 

--- a/account/utils.py
+++ b/account/utils.py
@@ -107,6 +107,14 @@ def get_form_data(form, field_name, default=None):
     return form.data.get(key, default)
 
 
+# https://stackoverflow.com/a/70419609/6461688
+def is_ajax(request):
+    """
+    Return True if the request was sent with XMLHttpRequest, False otherwise.
+    """
+    return request.META.get('HTTP_X_REQUESTED_WITH') == 'XMLHttpRequest'
+
+
 def check_password_expired(user):
     """
     Return True if password is expired and system is using

--- a/account/views.py
+++ b/account/views.py
@@ -36,7 +36,7 @@ from account.models import (
     PasswordHistory,
     SignupCode,
 )
-from account.utils import default_redirect, get_form_data
+from account.utils import default_redirect, get_form_data, is_ajax
 
 
 class PasswordMixin(object):
@@ -195,7 +195,7 @@ class SignupView(PasswordMixin, FormView):
         return initial
 
     def get_template_names(self):
-        if self.request.is_ajax():
+        if is_ajax(request):
             return [self.template_name_ajax]
         else:
             return [self.template_name]
@@ -327,7 +327,7 @@ class SignupView(PasswordMixin, FormView):
         return settings.ACCOUNT_OPEN_SIGNUP
 
     def email_confirmation_required_response(self):
-        if self.request.is_ajax():
+        if is_ajax(self.request):
             template_name = self.template_name_email_confirmation_sent_ajax
         else:
             template_name = self.template_name_email_confirmation_sent
@@ -342,7 +342,7 @@ class SignupView(PasswordMixin, FormView):
         return self.response_class(**response_kwargs)
 
     def closed(self):
-        if self.request.is_ajax():
+        if is_ajax(self.request):
             template_name = self.template_name_signup_closed_ajax
         else:
             template_name = self.template_name_signup_closed
@@ -373,7 +373,7 @@ class LoginView(FormView):
         return super(LoginView, self).get(*args, **kwargs)
 
     def get_template_names(self):
-        if self.request.is_ajax():
+        if is_ajax(self.request):
             return [self.template_name_ajax]
         else:
             return [self.template_name]

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -298,7 +298,7 @@ checker from `cracklib`_.::
 
     from django import forms from django.conf import settings from
     django.template.defaultfilters import mark_safe from
-    django.utils.translation import ugettext_lazy as _
+    django.utils.translation import gettext_lazy as _
 
     from account.hooks import AccountDefaultHookSet
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@ DJANGO_SETTINGS_MODULE = account.tests.settings
 
 [metadata]
 name = django-user-accounts
-version = 3.1.0
+version = 3.2.0
 author = Pinax Team
 author_email = team@pinaxproject.com
 description = a Django user account app


### PR DESCRIPTION
<!-- Closes # . -->

Changes proposed in this PR:

- Replace `ugettext_lazy` (removed in Django 4.0) with `gettext_lazy`

**Tips for an ideal PR**
* [x] You have read our Code of Conduct: https://github.com/pinax/.github/blob/master/CODE_OF_CONDUCT.md
* [x] You have read our Contributing info: https://github.com/pinax/.github/blob/master/CONTRIBUTING.md
* [x] The PR is atomic
* [ ] Unit tests have been updated/added, if needed - N/A
* [x] App version number has been updated in `setup.py` or `setup.cfg` (Pinax uses [SemVer](https://semver.org/))
* [x] `Change Log` has been updated
* [ ] You have added your name to the `AUTHORS` file - N/A