### PR TITLE
Use QuerySet.select_related() to avoid n+1 queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ version with these. Your code will need to be updated to continue working.
 ## 3.2.0
 
 * #363 - Django 4.0 compat: `ugettext_lazy` -> `gettext_lazy`
+* #364 - Performance fix to admin classes
 
 ## 3.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,13 @@
 BI indicates a backward incompatible change. Take caution when upgrading to a
 version with these. Your code will need to be updated to continue working.
 
+## 3.2.1
+
+* #364 - Performance fix to admin classes
+
 ## 3.2.0
 
 * #363 - Django 4.0 compat: `ugettext_lazy` -> `gettext_lazy`
-* #364 - Performance fix to admin classes
 
 ## 3.1.0
 

--- a/account/admin.py
+++ b/account/admin.py
@@ -22,6 +22,9 @@ class AccountAdmin(admin.ModelAdmin):
 
     raw_id_fields = ["user"]
 
+    def get_queryset(self, request):
+        return super().get_queryset(request).select_related('user')
+
 
 class AccountDeletionAdmin(AccountAdmin):
 
@@ -32,6 +35,9 @@ class EmailAddressAdmin(AccountAdmin):
 
     list_display = ["user", "email", "verified", "primary"]
     search_fields = ["email", "user__username"]
+
+    def get_queryset(self, request):
+        return super().get_queryset(request).select_related('user')
 
 
 class PasswordExpiryAdmin(admin.ModelAdmin):
@@ -45,6 +51,9 @@ class PasswordHistoryAdmin(admin.ModelAdmin):
     list_display = ["user", "timestamp"]
     list_filter = ["user"]
     ordering = ["user__username", "-timestamp"]
+
+    def get_queryset(self, request):
+        return super().get_queryset(request).select_related('user')
 
 
 admin.site.register(Account, AccountAdmin)

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@ DJANGO_SETTINGS_MODULE = account.tests.settings
 
 [metadata]
 name = django-user-accounts
-version = 3.2.0
+version = 3.2.1
 author = Pinax Team
 author_email = team@pinaxproject.com
 description = a Django user account app


### PR DESCRIPTION
Changes proposed in this PR:

- Add `.select_related('user')` to a few specific admins
  + `AccountAdmin` because [`Account.__str__()` returns `str(self.user)`](https://github.com/pinax/django-user-accounts/blob/e83effdd4a23cd8d830169904c261ff6677ee3e6/account/models.py#L66)
  + `EmailAddressAdmin` has the [`user` in `list_display`](https://github.com/pinax/django-user-accounts/blob/e83effdd4a23cd8d830169904c261ff6677ee3e6/account/admin.py#L33)
  + `PasswordHistoryAdmin` [orders on `user__username`](https://github.com/pinax/django-user-accounts/blob/e83effdd4a23cd8d830169904c261ff6677ee3e6/account/admin.py#L47)

**Tips for an ideal PR**
* [x] You have read our Code of Conduct: https://github.com/pinax/.github/blob/master/CODE_OF_CONDUCT.md
* [x] You have read our Contributing info: https://github.com/pinax/.github/blob/master/CONTRIBUTING.md
* [x] The PR is atomic
* [x] Unit tests have been updated/added, if needed - N/A
* [x] App version number has been updated in ~`setup.py`~ `setup.cfg` (Pinax uses [SemVer](https://semver.org/)) - ~N/A (see comment below)~ - done
* [x] `Change Log` has been updated
* [x] You have added your name to the `AUTHORS` file - N/A

